### PR TITLE
🐛 fix: do not display device credential if user clicks cancel

### DIFF
--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -302,7 +302,8 @@ public class KeychainModule extends ReactContextBaseJavaModule {
       try {
         decryptionResult = decryptCredentials(alias, cipher, resultSet, rules, promptInfo);
       } catch (CryptoFailedException e) {
-        if (isAndroidApi28Or29() && isBiometricOrDeviceCredential(options)) {
+        boolean isFailedMultipleTimes = e.getErrorCode() == CryptoFailedException.ErrorCode.FAILED_MULTIPLE_TIMES;
+        if (isAndroidApi28Or29() && isBiometricOrDeviceCredential(options) && isFailedMultipleTimes) {
           // fallback to device credential on Android API Level 28 or 29
           promptInfo = getDeviceCredentialPromptInfoForAndroidApi28Or29(options);
           decryptionResult = decryptCredentials(alias, cipher, resultSet, rules, promptInfo);

--- a/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometric.java
+++ b/android/src/main/java/com/oblador/keychain/decryptionHandler/DecryptionResultHandlerInteractiveBiometric.java
@@ -33,9 +33,9 @@ public class DecryptionResultHandlerInteractiveBiometric extends BiometricPrompt
   protected static final String LOG_TAG = DecryptionResultHandlerInteractiveBiometric.class.getSimpleName();
 
   public DecryptionResultHandlerInteractiveBiometric(
-                                                     @NonNull ReactApplicationContext reactContext,
-                                                     @NonNull final CipherStorage storage,
-                                                     @NonNull final BiometricPrompt.PromptInfo promptInfo) {
+    @NonNull ReactApplicationContext reactContext,
+    @NonNull final CipherStorage storage,
+    @NonNull final BiometricPrompt.PromptInfo promptInfo) {
     this.reactContext = reactContext;
     this.storage = (CipherStorageBase) storage;
     this.promptInfo = promptInfo;
@@ -80,7 +80,7 @@ public class DecryptionResultHandlerInteractiveBiometric extends BiometricPrompt
   /** Called when an unrecoverable error has been encountered and the operation is complete. */
   @Override
   public void onAuthenticationError(final int errorCode, @NonNull final CharSequence errString) {
-    final CryptoFailedException error = new CryptoFailedException("code: " + errorCode + ", msg: " + errString);
+    final CryptoFailedException error = new CryptoFailedException(errorCode, errString);
 
     onDecrypt(null, error);
   }

--- a/android/src/main/java/com/oblador/keychain/exceptions/CryptoFailedException.java
+++ b/android/src/main/java/com/oblador/keychain/exceptions/CryptoFailedException.java
@@ -5,12 +5,24 @@ import androidx.annotation.Nullable;
 import java.security.GeneralSecurityException;
 
 public class CryptoFailedException extends GeneralSecurityException {
+  public @interface ErrorCode {
+    int UNKNOWN = -1;
+    int CANCELLED = 13;
+    int FAILED_MULTIPLE_TIMES = 7;
+  }
+  private int errorCode = ErrorCode.UNKNOWN;
+
   public CryptoFailedException(String message) {
     super(message);
   }
 
   public CryptoFailedException(String message, Throwable t) {
     super(message, t);
+  }
+
+  public CryptoFailedException(int errorCode, CharSequence errString) {
+    super("code: " + errorCode + ", msg: " + errString);
+    this.errorCode = errorCode;
   }
 
   public static void reThrowOnError(@Nullable final Throwable error) throws CryptoFailedException {
@@ -21,5 +33,9 @@ public class CryptoFailedException extends GeneralSecurityException {
 
     throw new CryptoFailedException("Wrapped error: " + error.getMessage(), error);
 
+  }
+
+  public int getErrorCode() {
+    return errorCode;
   }
 }

--- a/android/src/main/java/com/oblador/keychain/exceptions/CryptoFailedException.java
+++ b/android/src/main/java/com/oblador/keychain/exceptions/CryptoFailedException.java
@@ -7,7 +7,8 @@ import java.security.GeneralSecurityException;
 public class CryptoFailedException extends GeneralSecurityException {
   public @interface ErrorCode {
     int UNKNOWN = -1;
-    int CANCELLED = 13;
+    int CANCEL_BUTTON_CLICKED = 13;
+    int CANCEL_BY_PRESS_OUTSIDE_PROMPT = 10;
     int FAILED_MULTIPLE_TIMES = 7;
   }
   private int errorCode = ErrorCode.UNKNOWN;


### PR DESCRIPTION
- fix: do not show device credential if user click cancel
- feat: add error code for CANCEL_BY_PRESS_OUTSIDE_PROMPT
