### PR TITLE
🚀 chore: publish to npm to resolve `The remote archive does not match the expected checksum`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-native-keychain",
-  "version": "8.1.1",
+  "name": "@coolwallet-app/react-native-keychain",
+  "version": "8.1.1-cbx.2",
   "description": "Keychain Access for React Native",
   "main": "index.js",
   "files": [
@@ -15,7 +15,8 @@
     "format": "prettier '{,typings/,KeychainExample/}*.{md,js,json,ts,tsx}' --write",
     "lint": "eslint .",
     "flow": "flow",
-    "test": "./gradlew test"
+    "test": "./gradlew test",
+    "deploy": "npm publish --access public"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
Published to https://www.npmjs.com/package/@coolwallet-app/react-native-keychain

 **PR Summary by Typo**
------------

**Overview:**
This PR updates the `package.json` to resolve checksum mismatches when installing the package. It renames the package and adds a pre-release tag to the version.  A publish command is also added to the scripts.

**Key Changes:**
- Changed package name from `react-native-keychain` to `@coolwallet-app/react-native-keychain`.
- Updated the version from `8.1.1` to `8.1.1-cbx.2`.
- Added a `deploy` script to publish the package with public access.

**Recommendations:**
Ready for deployment. This simple change effectively addresses the checksum issue and improves the package management process.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 1 (25.0%)      |
| Refactor    | 3 (75.0%)      |
| Total Changes | 4             |

 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>