### PR TITLE
chore: update package url

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint .",
     "flow": "flow",
     "test": "./gradlew test",
-    "deploy": "npm publish --access public"
+    "deploy": "yarn --frozen-lockfile --non-interactive --silent && npm publish --access public"
   },
   "keywords": [
     "react-native",
@@ -32,9 +32,9 @@
     "name": "Joel Arvidsson",
     "email": "joel@oblador.se"
   },
-  "homepage": "https://github.com/oblador/react-native-keychain",
+  "homepage": "https://github.com/CoolBitX-Technology/react-native-keychain",
   "bugs": {
-    "url": "https://github.com/oblador/react-native-keychain/issues"
+    "url": "https://github.com/CoolBitX-Technology/react-native-keychain/issues"
   },
   "typescript": {
     "definition": "typings/react-native-keychain.d.ts"
@@ -42,7 +42,7 @@
   "types": "typings/react-native-keychain.d.ts",
   "repository": {
     "type": "git",
-    "url": "git://github.com/oblador/react-native-keychain.git"
+    "url": "git://github.com/CoolBitX-Technology/react-native-keychain.git"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
- **chore: publish to npm to resolve `The remote archive does not match the expected checksum`**
- **chore: update package url**

 
 **PR Summary by Typo**
------------

**Overview:**
This PR updates the package URL and homepage in `package.json` from `oblador/react-native-keychain` to `CoolBitX-Technology/react-native-keychain`, reflecting a change in project ownership or maintenance.  It also modifies the deploy script to ensure dependencies are locked and updated silently.

**Key Changes:**
- Changed the repository URL and homepage in `package.json` to point to the new `CoolBitX-Technology` organization.
- Modified the `deploy` script to include `yarn --frozen-lockfile --non-interactive --silent` before publishing.

**Recommendations:**
Ready for deployment. This is a straightforward change with low risk.

### 🗂️ Work Breakdown

| Category | Lines Changed |
|---|---|
| Rework | 8 (100%) |
| Total Changes | 8 |


 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>