### PR TITLE
✨ feat: bio or passcode on android 10 for keychain v10

### DIFF
--- a/KeychainExample/src/App.tsx
+++ b/KeychainExample/src/App.tsx
@@ -10,7 +10,7 @@ import {
   View,
 } from 'react-native';
 import SegmentedControlTab from 'react-native-segmented-control-tab';
-import * as Keychain from 'react-native-keychain';
+import * as Keychain from '@coolwallet-app/react-native-keychain';
 
 const ACCESS_CONTROL_OPTIONS = ['None', 'Passcode', 'Password'];
 const ACCESS_CONTROL_OPTIONS_ANDROID = ['None', 'Passcode'];

--- a/KeychainExample/src/App.tsx
+++ b/KeychainExample/src/App.tsx
@@ -24,6 +24,7 @@ const ACCESS_CONTROL_MAP_ANDROID = [
   null,
   Keychain.ACCESS_CONTROL.DEVICE_PASSCODE,
   Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET,
+  Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE
 ];
 const SECURITY_LEVEL_OPTIONS = ['Any', 'Software', 'Hardware'];
 const SECURITY_LEVEL_MAP = [
@@ -131,7 +132,10 @@ export default function App() {
 
   const load = async () => {
     try {
+      const isAndroid = Platform.OS === 'android';
+      const wrappedAccessControl = isAndroid ? accessControl : undefined;
       const options = {
+        accessControl: wrappedAccessControl,
         authenticationPrompt: {
           title: 'Authentication needed',
           subtitle: 'Subtitle',
@@ -233,7 +237,7 @@ export default function App() {
           <Text style={styles.label}>Access Control</Text>
           <SegmentedControlTab
             selectedIndex={selectedAccessControlIndex}
-            values={biometryType ? [...AC_VALUES, biometryType] : AC_VALUES}
+            values={biometryType ? [...AC_VALUES, biometryType, 'BioOrPasscode'] : AC_VALUES}
             onTabPress={(index) => {
               setAccessControl(AC_MAP[index] || undefined);
               setSelectedAccessControlIndex(index);

--- a/KeychainExample/tsconfig.json
+++ b/KeychainExample/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@react-native/typescript-config/tsconfig.json",
   "compilerOptions": {
     "paths": {
-      "react-native-keychain": ["../src/index"]
+      "@coolwallet-app/react-native-keychain": ["../src/index"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@
    ```
 
 4. **部署至 npm（可選）**
-   
-   如果有相關改動需要發布：
+
+如果有相關改動需要發布：
+
+- 修改 package.json 版本號碼，通常是把 `x.x.x-cbx.0` 往上加一版 變成 `x.x.x-cbx.1`
+- 部署至 npm
    ```bash
    yarn run deploy
    ```

--- a/android/src/main/java/com/oblador/keychain/KeychainModule.kt
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.kt
@@ -6,6 +6,8 @@ import android.util.Log
 import androidx.annotation.StringDef
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
+import androidx.biometric.BiometricPrompt.ERROR_NEGATIVE_BUTTON
+import androidx.biometric.BiometricPrompt.ERROR_USER_CANCELED
 import androidx.biometric.BiometricPrompt.PromptInfo
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
@@ -302,7 +304,6 @@ class KeychainModule(reactContext: ReactApplicationContext) :
           var promptInfo = getPromptInfo(options, usePasscode, useBiometry)
           val cipher = getCipherStorageByName(storageName)
 
-          //
           var decryptionResult: DecryptionResult
           try {
             decryptionResult = decryptCredentials(alias, cipher!!, resultSet, promptInfo)
@@ -310,10 +311,12 @@ class KeychainModule(reactContext: ReactApplicationContext) :
             Log.e(KEYCHAIN_MODULE, "getGenericPassword error message:" + e.message);
 
             // fallback to device credential on Android API Level 28 or 29
-            if (e.message?.startsWith("code: 13") == true || e.message?.startsWith("code: 10") == true) {
-              // click cancel button: message="code: 13, msg: Cancel", androidx.biometric.BiometricPrompt.ERROR_USER_CANCELED = 10
-              // click backdrop: message="code: 10, msg: Authentication cancelled", androidx.biometric.BiometricPrompt.ERROR_NEGATIVE_BUTTON = 13
-              // cancel error message: "code: 13, msg: Cancel"
+            if (e.message?.startsWith("code: $ERROR_USER_CANCELED") == true || e.message?.startsWith("code: $ERROR_NEGATIVE_BUTTON") == true) {
+              // click backdrop: message="code: 10, msg: Authentication cancelled"
+              // click cancel button: message="code: 13, msg: Cancel"
+              //
+              // androidx.biometric.BiometricPrompt.ERROR_USER_CANCELED = 10
+              // androidx.biometric.BiometricPrompt.ERROR_NEGATIVE_BUTTON = 13
               throw e
             }
 
@@ -829,6 +832,7 @@ class KeychainModule(reactContext: ReactApplicationContext) :
       }
 
       val allowedAuthenticators = when {
+        // Android API 28, 29 do not support Authenticators.DEVICE_CREDENTIAL
         usePasscode && useBiometry && isAndroidApi28Or29() -> BiometricManager.Authenticators.BIOMETRIC_STRONG
 
         usePasscode && useBiometry ->
@@ -845,6 +849,8 @@ class KeychainModule(reactContext: ReactApplicationContext) :
         promptInfoBuilder.setAllowedAuthenticators(allowedAuthenticators)
       }
 
+      // Android API 28, 29 不支援 fallback 機制，所以 biometry 失敗或是 cancel 後不會 fallback 到 passcode。
+      // 因此在這兩個 Android 版本，要把原本按鈕上的文字 use passcode 改成 cancel。
       if (!usePasscode || isAndroidApi28Or29()) {
         promptInfoOptionsMap?.getString(AuthPromptOptions.CANCEL)?.let {
           promptInfoBuilder.setNegativeButtonText(it)

--- a/android/src/main/java/com/oblador/keychain/KeychainModule.kt
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.kt
@@ -5,6 +5,7 @@ import android.text.TextUtils
 import android.util.Log
 import androidx.annotation.StringDef
 import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
 import androidx.biometric.BiometricPrompt.PromptInfo
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
@@ -301,10 +302,21 @@ class KeychainModule(reactContext: ReactApplicationContext) :
           var promptInfo = getPromptInfo(options, usePasscode, useBiometry)
           val cipher = getCipherStorageByName(storageName)
 
+          //
           var decryptionResult: DecryptionResult
           try {
             decryptionResult = decryptCredentials(alias, cipher!!, resultSet, promptInfo)
           } catch (e: CryptoFailedException) {
+            Log.e(KEYCHAIN_MODULE, "getGenericPassword error message:" + e.message);
+
+            // fallback to device credential on Android API Level 28 or 29
+            if (e.message?.startsWith("code: 13") == true || e.message?.startsWith("code: 10") == true) {
+              // click cancel button: message="code: 13, msg: Cancel", androidx.biometric.BiometricPrompt.ERROR_USER_CANCELED = 10
+              // click backdrop: message="code: 10, msg: Authentication cancelled", androidx.biometric.BiometricPrompt.ERROR_NEGATIVE_BUTTON = 13
+              // cancel error message: "code: 13, msg: Cancel"
+              throw e
+            }
+
             if (isAndroidApi28Or29() && isBiometricOrDeviceCredential(options)) {
               // fallback to device credential on Android API Level 28 or 29
               promptInfo = getDeviceCredentialPromptInfoForAndroidApi28Or29(options)

--- a/android/src/main/java/com/oblador/keychain/KeychainModule.kt
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.kt
@@ -241,11 +241,6 @@ class KeychainModule(reactContext: ReactApplicationContext) :
     return result
   }
 
-  private fun isAndroidApi28Or29(): Boolean {
-    return Build.VERSION.SDK_INT == Build.VERSION_CODES.P
-      || Build.VERSION.SDK_INT == Build.VERSION_CODES.Q
-  }
-
   private fun isBiometricOrDeviceCredential(options: ReadableMap?): Boolean {
     val accessControl = getAccessControlOrDefault(options)
     return accessControl == AccessControl.BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE
@@ -715,6 +710,10 @@ class KeychainModule(reactContext: ReactApplicationContext) :
     const val EMPTY_STRING = ""
     private val LOG_TAG = KeychainModule::class.java.simpleName
 
+    private fun isAndroidApi28Or29(): Boolean {
+      return Build.VERSION.SDK_INT == Build.VERSION_CODES.P
+        || Build.VERSION.SDK_INT == Build.VERSION_CODES.Q
+    }
 
     // endregion
     // region Helpers
@@ -818,6 +817,8 @@ class KeychainModule(reactContext: ReactApplicationContext) :
       }
 
       val allowedAuthenticators = when {
+        usePasscode && useBiometry && isAndroidApi28Or29() -> BiometricManager.Authenticators.BIOMETRIC_STRONG
+
         usePasscode && useBiometry ->
           BiometricManager.Authenticators.BIOMETRIC_STRONG or BiometricManager.Authenticators.DEVICE_CREDENTIAL
 
@@ -832,7 +833,7 @@ class KeychainModule(reactContext: ReactApplicationContext) :
         promptInfoBuilder.setAllowedAuthenticators(allowedAuthenticators)
       }
 
-      if (!usePasscode) {
+      if (!usePasscode || isAndroidApi28Or29()) {
         promptInfoOptionsMap?.getString(AuthPromptOptions.CANCEL)?.let {
           promptInfoBuilder.setNegativeButtonText(it)
         }

--- a/android/src/main/java/com/oblador/keychain/KeychainModule.kt
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.kt
@@ -16,24 +16,23 @@ import com.facebook.react.module.annotations.ReactModule
 import com.oblador.keychain.cipherStorage.CipherCache
 import com.oblador.keychain.cipherStorage.CipherStorage
 import com.oblador.keychain.cipherStorage.CipherStorage.DecryptionResult
-import com.oblador.keychain.cipherStorage.CipherStorageBase
 import com.oblador.keychain.cipherStorage.CipherStorageKeystoreAesCbc
 import com.oblador.keychain.cipherStorage.CipherStorageKeystoreAesGcm
 import com.oblador.keychain.cipherStorage.CipherStorageKeystoreRsaEcb
-import com.oblador.keychain.resultHandler.ResultHandler
-import com.oblador.keychain.resultHandler.ResultHandlerProvider
 import com.oblador.keychain.exceptions.CryptoFailedException
 import com.oblador.keychain.exceptions.EmptyParameterException
 import com.oblador.keychain.exceptions.KeyStoreAccessException
+import com.oblador.keychain.resultHandler.ResultHandler
+import com.oblador.keychain.resultHandler.ResultHandlerProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.isActive
-import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+
 
 @ReactModule(name = KeychainModule.KEYCHAIN_MODULE)
 @Suppress("unused")
@@ -242,6 +241,53 @@ class KeychainModule(reactContext: ReactApplicationContext) :
     return result
   }
 
+  private fun isAndroidApi28Or29(): Boolean {
+    return Build.VERSION.SDK_INT == Build.VERSION_CODES.P
+      || Build.VERSION.SDK_INT == Build.VERSION_CODES.Q
+  }
+
+  private fun isBiometricOrDeviceCredential(options: ReadableMap?): Boolean {
+    val accessControl = getAccessControlOrDefault(options)
+    return accessControl == AccessControl.BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE
+      || accessControl == AccessControl.BIOMETRY_ANY_OR_DEVICE_PASSCODE
+  }
+
+  private fun getDeviceCredentialPromptInfoForAndroidApi28Or29(options: ReadableMap?): PromptInfo {
+    // DEVICE_CREDENTIAL alone is unsupported prior to API 30
+    val promptInfoBuilder: PromptInfo.Builder = getBasePromptInfoBuilder(options)
+    promptInfoBuilder.setDeviceCredentialAllowed(true)
+    return promptInfoBuilder.build()
+  }
+
+  private fun getBasePromptInfoBuilder(options: ReadableMap?): PromptInfo.Builder {
+    val promptInfoOptionsMap: ReadableMap? = getPromptInfoOptionsMap(options)
+    val promptInfoBuilder = PromptInfo.Builder()
+    if (null != promptInfoOptionsMap && promptInfoOptionsMap.hasKey(AuthPromptOptions.TITLE)) {
+      val promptInfoTitle = promptInfoOptionsMap.getString(AuthPromptOptions.TITLE)
+      promptInfoBuilder.setTitle(promptInfoTitle!!)
+    }
+    if (null != promptInfoOptionsMap && promptInfoOptionsMap.hasKey(AuthPromptOptions.SUBTITLE)) {
+      val promptInfoSubtitle = promptInfoOptionsMap.getString(AuthPromptOptions.SUBTITLE)
+      promptInfoBuilder.setSubtitle(promptInfoSubtitle)
+    }
+    if (null != promptInfoOptionsMap && promptInfoOptionsMap.hasKey(AuthPromptOptions.DESCRIPTION)) {
+      val promptInfoDescription = promptInfoOptionsMap.getString(AuthPromptOptions.DESCRIPTION)
+      promptInfoBuilder.setDescription(promptInfoDescription)
+    }
+
+    /* Bypass confirmation to avoid KeyStore unlock timeout being exceeded when using passive biometrics */
+    promptInfoBuilder.setConfirmationRequired(false)
+
+    return promptInfoBuilder
+  }
+
+  private fun getPromptInfoOptionsMap(options: ReadableMap?): ReadableMap? {
+    val promptInfoOptionsMap =
+      if (options != null && options.hasKey(Maps.AUTH_PROMPT)) options.getMap(Maps.AUTH_PROMPT)
+      else null
+    return promptInfoOptionsMap;
+  }
+
   private fun getGenericPassword(alias: String, options: ReadableMap?, promise: Promise) {
     coroutineScope.launch {
       mutex.withLock {
@@ -257,10 +303,22 @@ class KeychainModule(reactContext: ReactApplicationContext) :
           val usePasscode = getUsePasscode(accessControl) && isPasscodeAvailable
           val useBiometry =
             getUseBiometry(accessControl) && (isFingerprintAuthAvailable || isFaceAuthAvailable || isIrisAuthAvailable)
-          val promptInfo = getPromptInfo(options, usePasscode, useBiometry)
+          var promptInfo = getPromptInfo(options, usePasscode, useBiometry)
           val cipher = getCipherStorageByName(storageName)
-          val decryptionResult =
-            decryptCredentials(alias, cipher!!, resultSet, promptInfo)
+
+          var decryptionResult: DecryptionResult
+          try {
+            decryptionResult = decryptCredentials(alias, cipher!!, resultSet, promptInfo)
+          } catch (e: CryptoFailedException) {
+            if (isAndroidApi28Or29() && isBiometricOrDeviceCredential(options)) {
+              // fallback to device credential on Android API Level 28 or 29
+              promptInfo = getDeviceCredentialPromptInfoForAndroidApi28Or29(options)
+              decryptionResult = decryptCredentials(alias, cipher!!, resultSet, promptInfo)
+            } else {
+              throw e
+            }
+          }
+
           val credentials = Arguments.createMap()
           credentials.putString(Maps.SERVICE, alias)
           credentials.putString(Maps.USERNAME, decryptionResult.username)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet-app/react-native-keychain",
-  "version": "10.0.0-cbx.0",
+  "version": "10.0.0-cbx.1",
   "description": "Keychain Access for React Native",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coolwallet-app/react-native-keychain",
-  "version": "10.0.0-cbx.1",
+  "version": "10.0.0-cbx.2",
   "description": "Keychain Access for React Native",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index",


### PR DESCRIPTION
ref: https://github.com/CoolBitX-Technology/react-native-keychain/pull/3

test cases:

Given accessControl: BioOrPasscode on Android 10

- Biometric auth failed many times, then pin code screen is showing
- Click backdrop, then no pin code screen show
- Click cancel button, then no pin code screen show
- After biometric auth succeeded, username & password got
- After pin code auth succeeded, username & password got

@a0979470582:
實測 Keychain 行為(Android 15)：使用 Fingerprint 的方式將資料寫入 keychain，可以用 Passcode 讀取出來。
 
 
 
 **PR Summary by Typo**
------------

**Overview**
This PR introduces a new access control option for Android that allows biometric authentication to fall back to device passcode on Android API levels 28 and 29. It updates the `react-native-keychain` library to a custom package and refines the authentication flow for these specific Android versions.

**Key Changes**
- Switched the `react-native-keychain` dependency to `@coolwallet-app/react-native-keychain`.
- Added a `BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE` access control option for Android.
- Implemented specific logic in the Android module to allow biometric authentication to fall back to device passcode on Android API levels 28 and 29 if biometric authentication is canceled or fails.
- Adjusted the biometric prompt's negative button text (cancel instead of use passcode) for Android API 28/29 scenarios.
- Updated the README with new deployment instructions and incremented the package version.

**Recommendations**
ready for deployment. The changes address a specific Android behavior for older API versions, enhancing user authentication flexibility while maintaining clear code separation.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 85 (85.9%)    |
| Churn       | 1 (1.0%)      |
| Rework      | 13 (13.1%)    |
| Total Changes | 99            | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>